### PR TITLE
makefile: added -std=gnu99

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
 all:
-	gcc -g -o power power.c -liio -lm -Wall -Wextra
-	gcc -g -o cal_ad9361 cal_ad9361.c -lfftw3 -lpthread -liio -lm -Wall -Wextra
+	gcc -std=gnu99 -g -o power power.c -liio -lm -Wall -Wextra
+	gcc -std=gnu99 -g -o cal_ad9361 cal_ad9361.c -lfftw3 -lpthread -liio -lm -Wall -Wextra
 


### PR DESCRIPTION
Some PackRF boards didn't have cal_ad9361 application installed. I found out that building this repository fails. 

On some compilers, the default assumed standard will fail compilation
To avoid this I specified the C standard to compile the code with.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>